### PR TITLE
Add error reporting to @onboardjs/core.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onboardjs/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Headless core logic for dynamic onboarding flows.",
   "private": false,
   "author": {

--- a/packages/core/src/engine/OnboardingEngine.test.ts
+++ b/packages/core/src/engine/OnboardingEngine.test.ts
@@ -1426,6 +1426,19 @@ describe("OnboardingEngine", () => {
       const state = engine.getState();
       expect(state.currentStep?.id).toBe("step3"); // Should be on step3 (final operation)
     });
+
+    it("should allow external code to report errors", async () => {
+      const error = new Error("External error");
+      engine = new OnboardingEngine(basicConfig);
+      await engine.ready();
+
+      // Report an error
+      engine.reportError(error, "test-error");
+
+      const state = engine.getState();
+      expect(state.error).toEqual(error);
+      expect(state.isLoading).toBe(false);
+    });
   });
 
   describe("Concurrent Operations", () => {

--- a/packages/core/src/engine/OnboardingEngine.ts
+++ b/packages/core/src/engine/OnboardingEngine.ts
@@ -896,6 +896,17 @@ export class OnboardingEngine<
   }
 
   /**
+   * Allows plugins or external code to report an error to the engine's
+   * centralized error handler.
+   * @param error The error object or unknown value.
+   * @param operation A string describing the operation that failed (e.g., 'MyPlugin.saveData').
+   */
+  public reportError(error: unknown, operation: string): void {
+    // This method safely calls the internal handler with the correct context.
+    this.errorHandler.handleError(error, operation, this.contextInternal);
+  }
+
+  /**
    * Get checklist progress for current step
    */
   public getChecklistProgress(): ReturnType<


### PR DESCRIPTION
This PR adds the ability for external code (mainly meant for plugins) to report an error inside the `OnboardingEngine`.