### PR TITLE
Add PostHog tracking to React example

### DIFF
--- a/apps/examples/react-demo/.example.env
+++ b/apps/examples/react-demo/.example.env
@@ -1,0 +1,2 @@
+VITE_PUBLIC_POSTHOG_KEY=FILL_ME
+VITE_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com # Replace with your PostHog project host

--- a/apps/examples/react-demo/package.json
+++ b/apps/examples/react-demo/package.json
@@ -4,18 +4,20 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 3000",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
   "dependencies": {
     "@onboardjs/core": "^0.3.0",
+    "@onboardjs/posthog-plugin": "^1.0.0",
     "@onboardjs/react": "^0.3.0",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/vite": "^4.1.11",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",
+    "posthog-js": "^1.257.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/examples/react-demo/src/components/onboarding/onboarding-layout.tsx
+++ b/apps/examples/react-demo/src/components/onboarding/onboarding-layout.tsx
@@ -2,10 +2,20 @@ import { OnboardingProvider } from "@onboardjs/react";
 import OnboardingUI from "./onboarding-ui";
 import { stepRegistry } from "./step-registry";
 import { steps } from "./steps";
+import { createPostHogPlugin } from "@onboardjs/posthog-plugin";
+import posthog from "posthog-js";
+
+const posthogPlugin = createPostHogPlugin({
+  posthogInstance: posthog,
+  // We can enable debug logging during development
+  debug: process.env.NODE_ENV === "development",
+  enableConsoleLogging: process.env.NODE_ENV === "development",
+});
 
 export default function OnboardingLayout() {
   return (
     <OnboardingProvider
+      plugins={[posthogPlugin]}
       steps={steps}
       componentRegistry={stepRegistry}
       // Uncomment the following lines to enable localStorage persistence

--- a/apps/examples/react-demo/src/main.tsx
+++ b/apps/examples/react-demo/src/main.tsx
@@ -2,9 +2,18 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
+
+posthog.init(import.meta.env.VITE_PUBLIC_POSTHOG_KEY, {
+  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+  defaults: "2025-05-24",
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <PostHogProvider client={posthog}>
+      <App />
+    </PostHogProvider>
   </StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,11 +255,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@onboardjs/core": "^0.3.0",
+        "@onboardjs/posthog-plugin": "^1.0.0",
         "@onboardjs/react": "^0.3.0",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/vite": "^4.1.11",
         "clsx": "^2.1.1",
         "lucide-react": "^0.525.0",
+        "posthog-js": "^1.257.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",


### PR DESCRIPTION
This PR adds PostHog tracking to the React example.

![Code snippet of initialising PostHog in OnboardJS](https://github.com/user-attachments/assets/358d6d09-7916-4a45-9d7f-1ffd1779d118)
