### PR TITLE
(feat/core): Add a JSON Onboarding Step parser

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,5 +6,6 @@ export * from "./engine/ConfigurationBuilder";
 export * from "./engine/types"; // Export engine-specific types like EngineState
 export * from "./utils/step-utils";
 export * from "./plugins";
+export * from "./parser";
 
 export { validateFlow, type ValidationIssue } from "./utils/flow-validator";

--- a/packages/core/src/parser/StepJSONParser.test.ts
+++ b/packages/core/src/parser/StepJSONParser.test.ts
@@ -1,0 +1,614 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import StepJSONParser, { StepJSONParserUtils } from "./StepJSONParser";
+import { OnboardingStep } from "../types";
+import { StepJSONParserOptions } from "./types";
+
+const mockSteps: OnboardingStep[] = [
+  {
+    id: "welcome",
+    type: "INFORMATION",
+    payload: {
+      title: "Welcome!",
+      content: "This is the start of your journey.",
+    },
+    meta: { author: "Soma" },
+    nextStep: "choose-path",
+  },
+  {
+    id: "choose-path",
+    type: "SINGLE_CHOICE",
+    payload: {
+      title: "Choose Your Path",
+      options: [
+        { id: "dev", label: "Developer", value: "dev" },
+        { id: "design", label: "Designer", value: "design" },
+      ],
+    },
+    nextStep: (context) =>
+      context.data["choose-path"] === "dev" ? "dev-tools" : "design-tools",
+  },
+  {
+    id: "dev-tools",
+    type: "CHECKLIST",
+    payload: {
+      title: "Select Your Tools",
+      dataKey: "devtools",
+      items: [
+        { id: "vscode", label: "VS Code" },
+        { id: "git", label: "Git", isMandatory: true },
+        {
+          id: "docker",
+          label: "Docker",
+          condition: (context) => context.user.isPro,
+        },
+      ],
+    },
+    onStepComplete: () => {
+      console.log("Dev tools selected");
+    },
+  },
+  {
+    id: "custom-comp",
+    type: "CUSTOM_COMPONENT",
+    payload: {
+      componentKey: "UserProfileForm",
+    },
+    isSkippable: true,
+    skipToStep: "final",
+  },
+  {
+    id: "final",
+    type: "CONFIRMATION",
+    payload: {
+      title: "All Done!",
+    },
+  },
+];
+
+describe("StepJSONParser", () => {
+  describe("Core Serialization (toJSON)", () => {
+    it("should serialize steps to a JSON string with default options", () => {
+      const result = StepJSONParser.toJSON(mockSteps);
+      expect(result.success).toBe(true);
+      expect(typeof result.data).toBe("string");
+      const parsed = JSON.parse(result.data!);
+      expect(parsed.version).toBe("1.0.0");
+      expect(parsed.steps).toHaveLength(mockSteps.length);
+      expect(parsed.metadata).toBeDefined();
+    });
+
+    it("should pretty-print JSON when prettyPrint is true", () => {
+      const result = StepJSONParser.toJSON(mockSteps, { prettyPrint: true });
+      expect(result.data).toContain("\n");
+      expect(result.data).toContain("  ");
+    });
+
+    it("should omit metadata when includeMeta is false", () => {
+      const result = StepJSONParser.toJSON(mockSteps, { includeMeta: false });
+      const serialized = JSON.parse(result.data!);
+      const step = serialized.steps.find((s: any) => s.id === "welcome");
+      expect(step.meta).toBeUndefined();
+    });
+
+    it("should handle functions with 'serialize' option", () => {
+      const result = StepJSONParser.toJSON(mockSteps, {
+        functionHandling: "serialize",
+      });
+      const parsed = JSON.parse(result.data!);
+      const choosePathStep = parsed.steps.find(
+        (s: any) => s.id === "choose-path",
+      );
+      expect(choosePathStep.nextStep.__isFunction).toBe(true);
+      expect(choosePathStep.nextStep.__functionBody).toContain(
+        'context.data["choose-path"]',
+      );
+    });
+
+    it("should handle functions with 'omit' option", () => {
+      const result = StepJSONParser.toJSON(mockSteps, {
+        functionHandling: "omit",
+      });
+      const parsed = JSON.parse(result.data!);
+      const choosePathStep = parsed.steps.find(
+        (s: any) => s.id === "choose-path",
+      );
+      const devToolsStep = parsed.steps.find((s: any) => s.id === "dev-tools");
+      expect(choosePathStep.nextStep).toBeUndefined();
+      expect(devToolsStep.onStepComplete).toBeUndefined();
+    });
+
+    it("should handle functions with 'placeholder' option", () => {
+      const result = StepJSONParser.toJSON(mockSteps, {
+        functionHandling: "placeholder",
+      });
+      const parsed = JSON.parse(result.data!);
+      const choosePathStep = parsed.steps.find(
+        (s: any) => s.id === "choose-path",
+      );
+      expect(choosePathStep.nextStep.__isFunction).toBe(true);
+      expect(choosePathStep.nextStep.__functionBody).toContain("Placeholder");
+    });
+
+    it("should use a custom function serializer", () => {
+      const customSerializer = vi.fn(
+        (fn, propName, stepId) => `CUSTOMIZED::${stepId}::${propName}`,
+      );
+      const result = StepJSONParser.toJSON(mockSteps, {
+        customFunctionSerializer: customSerializer,
+      });
+      const parsed = JSON.parse(result.data!);
+      const choosePathStep = parsed.steps.find(
+        (s: any) => s.id === "choose-path",
+      );
+      expect(customSerializer).toHaveBeenCalled();
+      expect(choosePathStep.nextStep.__functionBody).toBe(
+        "CUSTOMIZED::choose-path::nextStep",
+      );
+    });
+  });
+
+  describe("Core Deserialization (fromJSON)", () => {
+    let serializedJSON: string;
+
+    beforeAll(() => {
+      const result = StepJSONParser.toJSON(mockSteps);
+      serializedJSON = result.data!;
+    });
+
+    it("should deserialize a JSON string to an array of steps", () => {
+      const result = StepJSONParser.fromJSON(serializedJSON);
+      expect(result.success).toBe(true);
+      expect(result.data).toBeInstanceOf(Array);
+      expect(result.data).toHaveLength(mockSteps.length);
+      const welcomeStep = result.data!.find((s) => s.id === "welcome");
+      expect(welcomeStep?.meta).toEqual({ author: "Soma" });
+    });
+
+    it("should correctly deserialize functions", () => {
+      const result = StepJSONParser.fromJSON(serializedJSON);
+      const choosePathStep = result.data!.find((s) => s.id === "choose-path");
+      const devToolsStep = result.data!.find((s) => s.id === "dev-tools");
+
+      expect(typeof choosePathStep?.nextStep).toBe("function");
+      expect(typeof devToolsStep?.onStepComplete).toBe("function");
+
+      // Test the deserialized function's logic
+      const mockContext = { data: { "choose-path": "dev" } };
+      expect((choosePathStep!.nextStep as Function)(mockContext)).toBe(
+        "dev-tools",
+      );
+    });
+
+    it("should use a custom function deserializer", () => {
+      const customDeserializer = vi.fn(
+        (fnString, propName, stepId) => () => `DESERIALIZED::${stepId}`,
+      );
+      const result = StepJSONParser.fromJSON(serializedJSON, {
+        customFunctionDeserializer: customDeserializer,
+      });
+      expect(customDeserializer).toHaveBeenCalled();
+      const choosePathStep = result.data!.find((s) => s.id === "choose-path");
+      const deserializedFn = choosePathStep!.nextStep as Function;
+      expect(deserializedFn()).toBe("DESERIALIZED::choose-path");
+    });
+
+    it("should handle invalid JSON gracefully", () => {
+      const result = StepJSONParser.fromJSON("{ not json }");
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain("Deserialization failed");
+    });
+
+    it("should handle JSON with missing 'steps' array", () => {
+      const result = StepJSONParser.fromJSON('{ "version": "1.0.0" }');
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain("Schema must contain a 'steps' array");
+    });
+  });
+
+  describe("End-to-End (Serialization -> Deserialization)", () => {
+    it("should produce a near-identical object after a full cycle", () => {
+      const result = StepJSONParser.toJSON(mockSteps);
+      expect(result.success).toBe(true);
+
+      const deserializedResult = StepJSONParser.fromJSON(result.data!);
+      expect(deserializedResult.success).toBe(true);
+
+      const original = mockSteps;
+      const final = deserializedResult.data!;
+
+      expect(final).toHaveLength(original.length);
+
+      // Check properties, accounting for functions
+      final.forEach((finalStep, i) => {
+        const originalStep = original[i];
+        expect(finalStep.id).toBe(originalStep.id);
+        expect(finalStep.type).toBe(originalStep.type);
+        expect(finalStep.payload?.title).toBe(originalStep.payload?.title);
+
+        // Check for function properties
+        if (typeof originalStep.nextStep === "function") {
+          expect(finalStep.nextStep).toEqual(expect.any(Function));
+        } else {
+          expect(finalStep.nextStep).toBe(originalStep.nextStep);
+        }
+
+        if (typeof originalStep.onStepComplete === "function") {
+          expect(finalStep.onStepComplete).toEqual(expect.any(Function));
+        }
+      });
+    });
+  });
+
+  describe("Validation Logic", () => {
+    it("should fail serialization if a step has a duplicate ID", () => {
+      const invalidSteps = [
+        { id: "step1", type: "INFORMATION" },
+        { id: "step1", type: "CONFIRMATION" },
+      ];
+      const result = StepJSONParser.toJSON(invalidSteps as any);
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain("Duplicate step ID found: 'step1'");
+    });
+
+    it("should fail serialization if a step is missing an ID", () => {
+      const invalidSteps = [{ type: "INFORMATION" }];
+      const result = StepJSONParser.toJSON(invalidSteps as any);
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain("missing required 'id' property");
+    });
+
+    it("should succeed serialization with invalid steps if validateSteps is false", () => {
+      const invalidSteps = [{ id: "step1" }, { id: "step1" }];
+      const result = StepJSONParser.toJSON(invalidSteps as any, {
+        validateSteps: false,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should include validation errors in output if requested", () => {
+      const invalidSteps = [{ id: "step1" }, { id: "step1" }];
+      const result = StepJSONParser.toJSON(invalidSteps as any, {
+        includeValidationErrors: true,
+      });
+      expect(result.success).toBe(false); // Still false because errors exist
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain("Duplicate step ID");
+    });
+
+    it("should report error for CHECKLIST step missing dataKey", () => {
+      const invalidSteps = [
+        {
+          id: "checklist-bad",
+          type: "CHECKLIST",
+          payload: { items: [{ id: "a", label: "A" }] },
+        },
+      ];
+      const result = StepJSONParser.toJSON(invalidSteps as any);
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toContain("must have dataKey property");
+    });
+  });
+
+  describe("Convenience Methods", () => {
+    it("serialize() should return a JSON string or null", () => {
+      const json = StepJSONParser.serialize(mockSteps);
+      expect(typeof json).toBe("string");
+
+      const invalidSteps = [{ id: "a" }, { id: "a" }];
+      const nullResult = StepJSONParser.serialize(invalidSteps as any);
+      expect(nullResult).toBeNull();
+    });
+
+    it("deserialize() should return an array of steps or null", () => {
+      const json = StepJSONParser.serialize(mockSteps);
+      const steps = StepJSONParser.deserialize(json!);
+      expect(steps).toBeInstanceOf(Array);
+      expect(steps).toHaveLength(mockSteps.length);
+
+      const nullResult = StepJSONParser.deserialize("{ not json }");
+      expect(nullResult).toBeNull();
+    });
+
+    it("clone() should create a deep copy of steps", () => {
+      const clonedSteps = StepJSONParser.clone(mockSteps);
+      expect(clonedSteps).not.toBe(mockSteps); // Different reference
+      // A simple deep equal check (ignoring function reference inequality)
+      expect(JSON.stringify(clonedSteps)).toEqual(
+        JSON.stringify(
+          StepJSONParser.deserialize(StepJSONParser.serialize(mockSteps)!),
+        ),
+      );
+    });
+  });
+
+  describe("getExportableData", () => {
+    // Mock data for these specific tests
+    const mockSteps: OnboardingStep[] = [{ id: "step1", type: "INFORMATION" }];
+
+    // Clean up spies after each test to ensure isolation
+    afterAll(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should return a successful result with the correct data structure on success", () => {
+      const mockJsonString = '{\n  "steps": []\n}';
+      const toJSONSpy = vi.spyOn(StepJSONParser, "toJSON").mockReturnValue({
+        success: true,
+        data: mockJsonString,
+        errors: [],
+        warnings: [],
+      });
+
+      const result = StepJSONParser.getExportableData(mockSteps);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data?.filename).toBe("onboarding-steps.json"); // Default filename
+      expect(result.data?.mimeType).toBe("application/json");
+      expect(result.data?.content).toBe(mockJsonString);
+      expect(result.errors).toEqual([]);
+      expect(result.warnings).toEqual([]);
+
+      expect(toJSONSpy).toHaveBeenCalledWith(mockSteps, { prettyPrint: true });
+    });
+
+    it("should return a failure result if the underlying toJSON call fails", () => {
+      const mockErrors = ["Serialization failed due to duplicate ID"];
+      const mockWarnings = ["Step 'step1' has an unknown type"];
+      vi.spyOn(StepJSONParser, "toJSON").mockReturnValue({
+        success: false,
+        data: undefined,
+        errors: mockErrors,
+        warnings: mockWarnings,
+      });
+
+      const result = StepJSONParser.getExportableData(mockSteps);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toBeUndefined();
+      expect(result.errors).toEqual(mockErrors);
+      expect(result.warnings).toEqual(mockWarnings);
+    });
+
+    it("should use a custom filename and pass options down to toJSON", () => {
+      const customFilename = "my-custom-flow.json";
+      const customOptions: Partial<StepJSONParserOptions> = {
+        includeMeta: false,
+        functionHandling: "omit",
+      };
+      const toJSONSpy = vi.spyOn(StepJSONParser, "toJSON").mockReturnValue({
+        success: true,
+        data: "{}",
+        errors: [],
+        warnings: [],
+      });
+
+      const result = StepJSONParser.getExportableData(
+        mockSteps,
+        customFilename,
+        customOptions,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data?.filename).toBe(customFilename);
+
+      expect(toJSONSpy).toHaveBeenCalledWith(mockSteps, {
+        ...customOptions,
+        prettyPrint: true, // `prettyPrint` is always forced to true
+      });
+    });
+  });
+
+  describe("StepJSONParserUtils Namespace", () => {
+    let validJson: string;
+    let invalidJson = "{ invalid }";
+
+    beforeAll(() => {
+      validJson = StepJSONParser.serialize(mockSteps)!;
+    });
+
+    it("isValidStepJSON() should correctly identify valid/invalid JSON", () => {
+      expect(StepJSONParserUtils.isValidStepJSON(validJson)).toBe(true);
+      expect(StepJSONParserUtils.isValidStepJSON(invalidJson)).toBe(false);
+      expect(StepJSONParserUtils.isValidStepJSON('{"steps":[]}')).toBe(false); // as per implementation
+    });
+
+    it("getStepTypesFromJSON() should return an array of step types", () => {
+      const types = StepJSONParserUtils.getStepTypesFromJSON(validJson);
+      expect(types).toEqual([
+        "INFORMATION",
+        "SINGLE_CHOICE",
+        "CHECKLIST",
+        "CUSTOM_COMPONENT",
+        "CONFIRMATION",
+      ]);
+      expect(StepJSONParserUtils.getStepTypesFromJSON(invalidJson)).toEqual([]);
+    });
+
+    it("getStepIdsFromJSON() should return an array of step IDs", () => {
+      const ids = StepJSONParserUtils.getStepIdsFromJSON(validJson);
+      expect(ids).toEqual([
+        "welcome",
+        "choose-path",
+        "dev-tools",
+        "custom-comp",
+        "final",
+      ]);
+      expect(StepJSONParserUtils.getStepIdsFromJSON(invalidJson)).toEqual([]);
+    });
+
+    it("hasCustomComponents() should detect custom component steps", () => {
+      expect(StepJSONParserUtils.hasCustomComponents(validJson)).toBe(true);
+      const noCustomCompJson = StepJSONParser.serialize(
+        mockSteps.filter((s) => s.type !== "CUSTOM_COMPONENT"),
+      )!;
+      expect(StepJSONParserUtils.hasCustomComponents(noCustomCompJson)).toBe(
+        false,
+      );
+    });
+
+    it("hasFunctions() should detect serialized functions", () => {
+      expect(StepJSONParserUtils.hasFunctions(validJson)).toBe(true);
+      const noFuncSteps = [
+        { id: "a", type: "INFORMATION", nextStep: "b" },
+        { id: "b", type: "CONFIRMATION" },
+      ];
+      const noFuncJson = StepJSONParser.serialize(noFuncSteps as any)!;
+      expect(StepJSONParserUtils.hasFunctions(noFuncJson)).toBe(false);
+    });
+  });
+
+  describe("Error Handling and Edge Cases", () => {
+    afterAll(() => {
+      // Restore any mocks after each test
+      vi.restoreAllMocks();
+    });
+
+    describe("toJSON", () => {
+      it("should handle a top-level serialization error", () => {
+        const circularObject: any = {};
+        circularObject.a = circularObject;
+        const stepsWithCircularRef = [{ id: "circular", meta: circularObject }];
+
+        const result = StepJSONParser.toJSON(stepsWithCircularRef as any);
+
+        expect(result.success).toBe(false);
+        expect(result.data).toBeUndefined();
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toMatch(/circular|cyclic/i);
+      });
+    });
+
+    describe("fromJSON", () => {
+      it("should handle invalid JSON during parsing", () => {
+        const invalidJsonString = "{ this is not valid json, }";
+
+        const result = StepJSONParser.fromJSON(invalidJsonString);
+
+        expect(result.success).toBe(false);
+        expect(result.data).toBeUndefined();
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain("Deserialization failed");
+        expect(result.errors[0]).toContain("Expected property name");
+      });
+    });
+
+    describe("serializeStep", () => {
+      it("should catch an error during individual step serialization", () => {
+        const errorMessage = "Schema is null or undefined";
+        vi.spyOn(StepJSONParser as any, "serializePayload").mockImplementation(
+          () => {
+            throw new Error(errorMessage);
+          },
+        );
+        const steps = [{ id: "step1", type: "INFORMATION", payload: {} }];
+
+        const result = StepJSONParser.toJSON(steps as any);
+
+        expect(result.success).toBe(false); // The error is pushed, so success is false
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain("Failed to serialize step step1");
+        expect(result.errors[0]).toContain(errorMessage);
+
+        // Check that the returned step is the minimal fallback
+        const parsedData = JSON.parse(result.data!);
+        expect(parsedData.steps[0]).toEqual({
+          id: "step1",
+          type: "INFORMATION",
+        });
+      });
+    });
+
+    describe("serializePayload", () => {
+      it("should catch an error when a payload has an invalid structure", () => {
+        const invalidSteps = [
+          {
+            id: "bad-payload",
+            type: "MULTIPLE_CHOICE",
+            payload: {
+              title: "Invalid",
+              options: null, // This will cause a TypeError
+            },
+          },
+        ];
+
+        const result = StepJSONParser.toJSON(invalidSteps as any);
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain(
+          "Step 'bad-payload' of type 'MULTIPLE_CHOICE' must have non-empty options array",
+        );
+      });
+    });
+
+    describe("deserializeStep", () => {
+      it("should catch an error during individual step deserialization", () => {
+        const validJson = StepJSONParser.serialize([
+          { id: "s1", type: "INFORMATION", payload: {} },
+        ])!;
+        const errorMessage = "Schema is null or undefined";
+        vi.spyOn(
+          StepJSONParser as any,
+          "deserializePayload",
+        ).mockImplementation(() => {
+          throw new Error(errorMessage);
+        });
+
+        const result = StepJSONParser.fromJSON(validJson);
+
+        expect(result.success).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain("Schema is null or undefined");
+        expect(result.errors[0]).toContain(errorMessage);
+        expect(result.data).toEqual(undefined);
+      });
+    });
+
+    describe("deserializeFunction", () => {
+      it("should catch syntax errors in a function body and return a no-op", () => {
+        const consoleWarnSpy = vi
+          .spyOn(console, "warn")
+          .mockImplementation(() => {});
+        const invalidSerializedFunc = {
+          __isFunction: true,
+          __functionBody: "return { this is invalid syntax",
+        };
+
+        const resultFn = (StepJSONParser as any).deserializeFunction(
+          invalidSerializedFunc,
+          "testProp",
+          "testId",
+          {},
+        );
+
+        expect(consoleWarnSpy).toHaveBeenCalled();
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "Failed to deserialize function testProp for step testId:",
+          expect.any(SyntaxError),
+        );
+        expect(typeof resultFn).toBe("function");
+        // The fallback function should do nothing and return undefined
+        expect(resultFn()).toBeUndefined();
+
+        consoleWarnSpy.mockRestore();
+      });
+    });
+
+    describe("StepJSONParserUtils", () => {
+      it("should handle invalid JSON gracefully", () => {
+        const invalidJson = "{ not json }";
+        expect(StepJSONParserUtils.isValidStepJSON(invalidJson)).toBe(false);
+        expect(StepJSONParserUtils.getStepTypesFromJSON(invalidJson)).toEqual(
+          [],
+        );
+        expect(StepJSONParserUtils.getStepIdsFromJSON(invalidJson)).toEqual([]);
+        expect(StepJSONParserUtils.hasCustomComponents(invalidJson)).toBe(
+          false,
+        );
+        expect(StepJSONParserUtils.hasFunctions(invalidJson)).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/core/src/parser/StepJSONParser.ts
+++ b/packages/core/src/parser/StepJSONParser.ts
@@ -1,0 +1,969 @@
+// @onboardjs/core/src/utils/StepJSONParser.ts
+
+import {
+  OnboardingStep,
+  OnboardingContext,
+  OnboardingStepType,
+  MultipleChoiceStepPayload,
+  SingleChoiceStepPayload,
+  CustomComponentStepPayload,
+  ChecklistStepPayload,
+} from "../types";
+import {
+  StepJSONParserOptions,
+  ParseResult,
+  StepJSONSchema,
+  SerializedStep,
+  SerializedFunction,
+  SerializedPayload,
+  SerializedInformationPayload,
+  SerializedMultipleChoicePayload,
+  SerializedSingleChoicePayload,
+  SerializedConfirmationPayload,
+  SerializedCustomComponentPayload,
+  SerializedChecklistPayload,
+  SerializedChoiceOption,
+  SerializedChecklistItem,
+  ExportData,
+} from "./types";
+
+export class StepJSONParser {
+  private static readonly VERSION = "1.0.0";
+  private static readonly DEFAULT_OPTIONS: StepJSONParserOptions = {
+    functionHandling: "serialize",
+    includeMeta: true,
+    validateSteps: true,
+    preserveTypes: true,
+    prettyPrint: false,
+    includeValidationErrors: false,
+  };
+
+  /**
+   * Serialize OnboardingStep[] to JSON string
+   */
+  static toJSON<TContext extends OnboardingContext = OnboardingContext>(
+    steps: OnboardingStep<TContext>[],
+    options: Partial<StepJSONParserOptions> = {},
+  ): ParseResult<string> {
+    const opts = { ...this.DEFAULT_OPTIONS, ...options };
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    try {
+      // Validate steps if requested
+      if (opts.validateSteps) {
+        const validationResult = this.validateSteps(steps);
+        errors.push(...validationResult.errors);
+        warnings.push(...validationResult.warnings);
+
+        if (
+          validationResult.errors.length > 0 &&
+          !opts.includeValidationErrors
+        ) {
+          return {
+            success: false,
+            errors,
+            warnings,
+          };
+        }
+      }
+
+      // Serialize steps
+      const serializedSteps = steps.map((step, index) =>
+        this.serializeStep(step, index, opts, errors, warnings),
+      );
+
+      // Create schema
+      const schema: StepJSONSchema = {
+        version: this.VERSION,
+        steps: serializedSteps,
+        metadata: {
+          exportedAt: new Date().toISOString(),
+          totalSteps: steps.length,
+          stepTypes: [...new Set(steps.map((s) => s.type || "INFORMATION"))],
+          hasCustomComponents: steps.some((s) => s.type === "CUSTOM_COMPONENT"),
+          hasFunctions: this.hasAnyFunctions(steps),
+        },
+      };
+
+      const jsonString = opts.prettyPrint
+        ? JSON.stringify(schema, null, 2)
+        : JSON.stringify(schema);
+
+      return {
+        success: errors.length === 0,
+        data: jsonString,
+        errors,
+        warnings,
+      };
+    } catch (error) {
+      errors.push(
+        `Serialization failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        success: false,
+        errors,
+        warnings,
+      };
+    }
+  }
+
+  /**
+   * Deserialize JSON string to OnboardingStep[]
+   */
+  static fromJSON<TContext extends OnboardingContext = OnboardingContext>(
+    jsonString: string,
+    options: Partial<StepJSONParserOptions> = {},
+  ): ParseResult<OnboardingStep<TContext>[]> {
+    const opts = { ...this.DEFAULT_OPTIONS, ...options };
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    try {
+      // Parse JSON
+      const schema = JSON.parse(jsonString) as StepJSONSchema;
+
+      // Validate schema
+      const schemaValidation = this.validateSchema(schema);
+      errors.push(...schemaValidation.errors);
+      warnings.push(...schemaValidation.warnings);
+
+      if (schemaValidation.errors.length > 0) {
+        return {
+          success: false,
+          errors,
+          warnings,
+        };
+      }
+
+      // Deserialize steps
+      const steps = schema.steps
+        .map((serializedStep, index) =>
+          this.deserializeStep<TContext>(
+            serializedStep,
+            index,
+            opts,
+            errors,
+            warnings,
+          ),
+        )
+        .filter((step): step is OnboardingStep<TContext> => step !== null);
+
+      // Validate deserialized steps if requested
+      if (opts.validateSteps) {
+        const validationResult = this.validateSteps(steps);
+        errors.push(...validationResult.errors);
+        warnings.push(...validationResult.warnings);
+      }
+
+      return {
+        success: errors.length === 0,
+        data: steps,
+        errors,
+        warnings,
+      };
+    } catch (error) {
+      errors.push(
+        `Deserialization failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        success: false,
+        errors,
+        warnings,
+      };
+    }
+  }
+
+  // =============================================================================
+  // STEP SERIALIZATION
+  // =============================================================================
+
+  private static serializeStep<TContext extends OnboardingContext>(
+    step: OnboardingStep<TContext>,
+    index: number,
+    options: StepJSONParserOptions,
+    errors: string[],
+    warnings: string[],
+  ): SerializedStep {
+    try {
+      const serialized: SerializedStep = {
+        id: step.id,
+      };
+
+      // Handle type
+      if (step.type) {
+        serialized.type = step.type;
+      }
+
+      // Handle navigation properties
+      serialized.nextStep = this.serializeStepProperty(
+        step.nextStep,
+        "nextStep",
+        step.id,
+        options,
+      );
+      serialized.previousStep = this.serializeStepProperty(
+        step.previousStep,
+        "previousStep",
+        step.id,
+        options,
+      );
+
+      // Handle skippable properties
+      if (step.isSkippable !== undefined) {
+        serialized.isSkippable = step.isSkippable;
+        if (step.isSkippable && (step as any).skipToStep !== undefined) {
+          serialized.skipToStep = this.serializeStepProperty(
+            (step as any).skipToStep,
+            "skipToStep",
+            step.id,
+            options,
+          );
+        }
+      }
+
+      // Handle function properties
+      if (step.onStepActive && options.functionHandling !== "omit") {
+        serialized.onStepActive = this.serializeFunction(
+          step.onStepActive,
+          "onStepActive",
+          step.id,
+          options,
+        );
+      }
+
+      if (step.onStepComplete && options.functionHandling !== "omit") {
+        serialized.onStepComplete = this.serializeFunction(
+          step.onStepComplete,
+          "onStepComplete",
+          step.id,
+          options,
+        );
+      }
+
+      if (step.condition && options.functionHandling !== "omit") {
+        serialized.condition = this.serializeFunction(
+          step.condition,
+          "condition",
+          step.id,
+          options,
+        );
+      }
+
+      // Handle payload
+      if (step.payload) {
+        serialized.payload = this.serializePayload(
+          step,
+          options,
+          errors,
+          warnings,
+        );
+      }
+
+      // Handle metadata
+      if (options.includeMeta && step.meta) {
+        serialized.meta = { ...step.meta };
+      }
+
+      // Handle type preservation
+      if (options.preserveTypes) {
+        serialized.__type = step.type || "INFORMATION";
+        serialized.__version = this.VERSION;
+      }
+
+      return serialized;
+    } catch (error) {
+      errors.push(
+        `Failed to serialize step ${step.id} at index ${index}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      // Return minimal valid step
+      return {
+        id: step.id,
+        type: step.type,
+      };
+    }
+  }
+
+  private static serializeStepProperty(
+    property: any,
+    propertyName: string,
+    stepId: string | number,
+    options: StepJSONParserOptions,
+  ): string | number | null | SerializedFunction | undefined {
+    if (property === undefined) return undefined;
+    if (property === null) return null;
+    if (typeof property === "string" || typeof property === "number") {
+      return property;
+    }
+    if (typeof property === "function") {
+      if (options.functionHandling === "omit") return undefined;
+      return this.serializeFunction(property, propertyName, stepId, options);
+    }
+    return property;
+  }
+
+  private static serializeFunction(
+    fn: Function,
+    propertyName: string,
+    stepId: string | number,
+    options: StepJSONParserOptions,
+  ): SerializedFunction {
+    if (options.functionHandling === "placeholder") {
+      return {
+        __isFunction: true,
+        __functionBody: `// Placeholder for ${propertyName} function`,
+        __functionName: fn.name || propertyName,
+      };
+    }
+
+    if (options.customFunctionSerializer) {
+      const customSerialized = options.customFunctionSerializer(
+        fn,
+        propertyName,
+        stepId,
+      );
+      return {
+        __isFunction: true,
+        __functionBody: customSerialized,
+        __functionName: fn.name || propertyName,
+      };
+    }
+
+    // Default serialization
+    const functionString = fn.toString();
+    const parameters = this.extractFunctionParameters(functionString);
+
+    return {
+      __isFunction: true,
+      __functionBody: functionString,
+      __functionName: fn.name || propertyName,
+      __parameters: parameters,
+    };
+  }
+
+  private static serializePayload<TContext extends OnboardingContext>(
+    step: OnboardingStep<TContext>,
+    options: StepJSONParserOptions,
+    errors: string[],
+    warnings: string[],
+  ): SerializedPayload | undefined {
+    if (!step.payload) return undefined;
+
+    const stepType = step.type || "INFORMATION";
+
+    try {
+      switch (stepType) {
+        case "INFORMATION":
+          return {
+            ...step.payload,
+            __payloadType: "INFORMATION",
+          } as SerializedInformationPayload;
+
+        case "MULTIPLE_CHOICE":
+          const mcPayload = step.payload as MultipleChoiceStepPayload;
+          return {
+            ...mcPayload,
+            __payloadType: "MULTIPLE_CHOICE",
+            options:
+              mcPayload.options?.map((opt) => ({
+                ...opt,
+                value: opt.value,
+              })) || [],
+          } as SerializedMultipleChoicePayload;
+
+        case "SINGLE_CHOICE":
+          const scPayload = step.payload as SingleChoiceStepPayload;
+          return {
+            ...scPayload,
+            __payloadType: "SINGLE_CHOICE",
+            options:
+              scPayload.options?.map((opt) => ({
+                ...opt,
+                value: opt.value,
+              })) || [],
+          } as SerializedSingleChoicePayload;
+
+        case "CONFIRMATION":
+          return {
+            ...step.payload,
+            __payloadType: "CONFIRMATION",
+          } as SerializedConfirmationPayload;
+
+        case "CUSTOM_COMPONENT":
+          return {
+            ...step.payload,
+            __payloadType: "CUSTOM_COMPONENT",
+          } as SerializedCustomComponentPayload;
+
+        case "CHECKLIST":
+          const clPayload = step.payload as ChecklistStepPayload<TContext>;
+          return {
+            ...clPayload,
+            __payloadType: "CHECKLIST",
+            items:
+              clPayload.items?.map((item) => ({
+                id: item.id,
+                label: item.label,
+                description: item.description,
+                isMandatory: item.isMandatory,
+                condition:
+                  item.condition && options.functionHandling !== "omit"
+                    ? this.serializeFunction(
+                        item.condition,
+                        "condition",
+                        step.id,
+                        options,
+                      )
+                    : undefined,
+                meta: item.meta,
+              })) || [],
+          } as SerializedChecklistPayload<TContext>;
+
+        default:
+          warnings.push(`Unknown step type '${stepType}' for step ${step.id}`);
+          return step.payload as any;
+      }
+    } catch (error) {
+      errors.push(
+        `Failed to serialize payload for step ${step.id}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return undefined;
+    }
+  }
+
+  private static deserializeStep<TContext extends OnboardingContext>(
+    serializedStep: SerializedStep,
+    index: number,
+    options: StepJSONParserOptions,
+    errors: string[],
+    warnings: string[],
+  ): OnboardingStep<TContext> | null {
+    try {
+      const step: Partial<OnboardingStep<TContext>> = {
+        id: serializedStep.id,
+      };
+
+      // Handle type
+      if (serializedStep.type) {
+        (step as any).type = serializedStep.type;
+      }
+
+      // Handle navigation properties
+      step.nextStep = this.deserializeStepProperty(
+        serializedStep.nextStep,
+        "nextStep",
+        serializedStep.id,
+        options,
+      ) as any;
+
+      step.previousStep = this.deserializeStepProperty(
+        serializedStep.previousStep,
+        "previousStep",
+        serializedStep.id,
+        options,
+      ) as any;
+
+      // Handle skippable properties
+      if (serializedStep.isSkippable !== undefined) {
+        (step as any).isSkippable = serializedStep.isSkippable;
+        if (
+          serializedStep.isSkippable &&
+          serializedStep.skipToStep !== undefined
+        ) {
+          (step as any).skipToStep = this.deserializeStepProperty(
+            serializedStep.skipToStep,
+            "skipToStep",
+            serializedStep.id,
+            options,
+          );
+        }
+      }
+
+      // Handle function properties
+      if (serializedStep.onStepActive) {
+        step.onStepActive = this.deserializeFunction(
+          serializedStep.onStepActive,
+          "onStepActive",
+          serializedStep.id,
+          options,
+        ) as any;
+      }
+
+      if (serializedStep.onStepComplete) {
+        step.onStepComplete = this.deserializeFunction(
+          serializedStep.onStepComplete,
+          "onStepComplete",
+          serializedStep.id,
+          options,
+        ) as any;
+      }
+
+      if (serializedStep.condition) {
+        step.condition = this.deserializeFunction(
+          serializedStep.condition,
+          "condition",
+          serializedStep.id,
+          options,
+        ) as any;
+      }
+
+      // Handle payload
+      if (serializedStep.payload) {
+        step.payload = this.deserializePayload<TContext>(
+          serializedStep.payload,
+          serializedStep.type,
+          options,
+          errors,
+          warnings,
+        );
+      }
+
+      // Handle metadata
+      if (serializedStep.meta) {
+        step.meta = { ...serializedStep.meta };
+      }
+
+      return step as OnboardingStep<TContext>;
+    } catch (error) {
+      errors.push(
+        `Failed to deserialize step at index ${index}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  }
+
+  private static deserializeStepProperty(
+    property: any,
+    propertyName: string,
+    stepId: string | number,
+    options: StepJSONParserOptions,
+  ): any {
+    if (property === undefined || property === null) return property;
+    if (typeof property === "string" || typeof property === "number") {
+      return property;
+    }
+    if (this.isSerializedFunction(property)) {
+      return this.deserializeFunction(property, propertyName, stepId, options);
+    }
+    return property;
+  }
+
+  private static deserializeFunction(
+    serializedFunction: SerializedFunction,
+    propertyName: string,
+    stepId: string | number,
+    options: StepJSONParserOptions,
+  ): Function {
+    if (options.customFunctionDeserializer) {
+      return options.customFunctionDeserializer(
+        serializedFunction.__functionBody,
+        propertyName,
+        stepId,
+      );
+    }
+
+    try {
+      // Create function from string
+      // This is a security risk in production - consider alternatives
+      return new Function(`return ${serializedFunction.__functionBody}`)();
+    } catch (error) {
+      console.warn(
+        `Failed to deserialize function ${propertyName} for step ${stepId}:`,
+        error,
+      );
+      // Return a no-op function as fallback
+      return () => {};
+    }
+  }
+
+  private static deserializePayload<TContext extends OnboardingContext>(
+    serializedPayload: SerializedPayload,
+    stepType?: OnboardingStepType,
+    options?: StepJSONParserOptions,
+    errors?: string[],
+    warnings?: string[],
+  ): any {
+    const payloadType =
+      (serializedPayload as any).__payloadType || stepType || "INFORMATION";
+
+    try {
+      switch (payloadType) {
+        case "INFORMATION":
+          const infoPayload = { ...serializedPayload };
+          delete (infoPayload as any).__payloadType;
+          return infoPayload;
+
+        case "MULTIPLE_CHOICE":
+        case "SINGLE_CHOICE":
+          const choicePayload = { ...serializedPayload } as any;
+          delete choicePayload.__payloadType;
+          if (choicePayload.options) {
+            choicePayload.options = choicePayload.options.map(
+              (opt: SerializedChoiceOption) => ({
+                ...opt,
+                value: opt.value,
+              }),
+            );
+          }
+          return choicePayload;
+
+        case "CONFIRMATION":
+          const confirmPayload = { ...serializedPayload };
+          delete (confirmPayload as any).__payloadType;
+          return confirmPayload;
+
+        case "CUSTOM_COMPONENT":
+          const customPayload = { ...serializedPayload };
+          delete (customPayload as any).__payloadType;
+          return customPayload;
+
+        case "CHECKLIST":
+          const checklistPayload = { ...serializedPayload } as any;
+          delete checklistPayload.__payloadType;
+          if (checklistPayload.items) {
+            checklistPayload.items = checklistPayload.items.map(
+              (item: SerializedChecklistItem) => ({
+                id: item.id,
+                label: item.label,
+                description: item.description,
+                isMandatory: item.isMandatory,
+                condition:
+                  item.condition && this.isSerializedFunction(item.condition)
+                    ? this.deserializeFunction(
+                        item.condition,
+                        "condition",
+                        item.id,
+                        options!,
+                      )
+                    : undefined,
+                meta: item.meta,
+              }),
+            );
+          }
+          return checklistPayload;
+
+        default:
+          warnings?.push(`Unknown payload type '${payloadType}'`);
+          return serializedPayload;
+      }
+    } catch (error) {
+      errors?.push(
+        `Failed to deserialize payload of type '${payloadType}': ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return serializedPayload;
+    }
+  }
+
+  private static isSerializedFunction(obj: any): obj is SerializedFunction {
+    return obj && typeof obj === "object" && obj.__isFunction === true;
+  }
+
+  private static extractFunctionParameters(functionString: string): string[] {
+    try {
+      const match = functionString.match(/\(([^)]*)\)/);
+      if (!match || !match[1]) return [];
+
+      return match[1]
+        .split(",")
+        .map((param) => param.trim())
+        .filter((param) => param.length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  private static hasAnyFunctions<TContext extends OnboardingContext>(
+    steps: OnboardingStep<TContext>[],
+  ): boolean {
+    return steps.some(
+      (step) =>
+        typeof step.nextStep === "function" ||
+        typeof step.previousStep === "function" ||
+        typeof (step as any).skipToStep === "function" ||
+        typeof step.onStepActive === "function" ||
+        typeof step.onStepComplete === "function" ||
+        typeof step.condition === "function" ||
+        (step.type === "CHECKLIST" &&
+          (step.payload as ChecklistStepPayload<TContext>)?.items?.some(
+            (item) => typeof item.condition === "function",
+          )),
+    );
+  }
+
+  private static validateSteps<TContext extends OnboardingContext>(
+    steps: OnboardingStep<TContext>[],
+  ): { errors: string[]; warnings: string[] } {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const stepIds = new Set<string | number>();
+
+    if (!steps || steps.length === 0) {
+      warnings.push("No steps provided");
+      return { errors, warnings };
+    }
+
+    steps.forEach((step, index) => {
+      // Check for required properties
+      if (!step.id) {
+        errors.push(`Step at index ${index} is missing required 'id' property`);
+        return;
+      }
+
+      // Check for duplicate IDs
+      if (stepIds.has(step.id)) {
+        errors.push(`Duplicate step ID found: '${step.id}'`);
+      }
+      stepIds.add(step.id);
+
+      // Validate step type
+      const validTypes: OnboardingStepType[] = [
+        "INFORMATION",
+        "MULTIPLE_CHOICE",
+        "SINGLE_CHOICE",
+        "CONFIRMATION",
+        "CUSTOM_COMPONENT",
+        "CHECKLIST",
+      ];
+
+      if (step.type && !validTypes.includes(step.type)) {
+        warnings.push(`Step '${step.id}' has unknown type '${step.type}'`);
+      }
+
+      // Validate payload based on type
+      this.validateStepPayload(step, errors, warnings);
+    });
+
+    return { errors, warnings };
+  }
+
+  private static validateStepPayload<TContext extends OnboardingContext>(
+    step: OnboardingStep<TContext>,
+    errors: string[],
+    warnings: string[],
+  ): void {
+    if (!step.payload) {
+      if (step.type && !["INFORMATION", "CONFIRMATION"].includes(step.type)) {
+        warnings.push(
+          `Step '${step.id}' of type '${step.type}' is missing payload`,
+        );
+      }
+      return;
+    }
+
+    switch (step.type) {
+      case "MULTIPLE_CHOICE":
+      case "SINGLE_CHOICE":
+        const choicePayload = step.payload as
+          | MultipleChoiceStepPayload
+          | SingleChoiceStepPayload;
+        if (
+          !choicePayload.options ||
+          !Array.isArray(choicePayload.options) ||
+          choicePayload.options.length === 0
+        ) {
+          errors.push(
+            `Step '${step.id}' of type '${step.type}' must have non-empty options array`,
+          );
+        }
+        break;
+
+      case "CHECKLIST":
+        const checklistPayload = step.payload as ChecklistStepPayload<TContext>;
+        if (
+          !checklistPayload.items ||
+          !Array.isArray(checklistPayload.items) ||
+          checklistPayload.items.length === 0
+        ) {
+          errors.push(
+            `Step '${step.id}' of type 'CHECKLIST' must have non-empty items array`,
+          );
+        }
+        if (!checklistPayload.dataKey) {
+          errors.push(
+            `Step '${step.id}' of type 'CHECKLIST' must have dataKey property`,
+          );
+        }
+        break;
+
+      case "CUSTOM_COMPONENT":
+        const customPayload = step.payload as CustomComponentStepPayload;
+        if (!customPayload.componentKey) {
+          warnings.push(
+            `Step '${step.id}' of type 'CUSTOM_COMPONENT' should have componentKey`,
+          );
+        }
+        break;
+    }
+  }
+
+  private static validateSchema(schema: any): {
+    errors: string[];
+    warnings: string[];
+  } {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    if (!schema) {
+      errors.push("Schema is null or undefined");
+      return { errors, warnings };
+    }
+
+    if (!schema.version) {
+      warnings.push("Schema is missing version information");
+    }
+
+    if (!schema.steps || !Array.isArray(schema.steps)) {
+      errors.push("Schema must contain a 'steps' array");
+      return { errors, warnings };
+    }
+
+    if (schema.steps.length === 0) {
+      warnings.push("Schema contains no steps");
+    }
+
+    return { errors, warnings };
+  }
+
+  // =============================================================================
+  // CONVENIENCE METHODS
+  // =============================================================================
+
+  /**
+   * Quick serialize with default options
+   */
+  static serialize<TContext extends OnboardingContext = OnboardingContext>(
+    steps: OnboardingStep<TContext>[],
+    prettyPrint: boolean = false,
+  ): string | null {
+    const result = this.toJSON(steps, { prettyPrint });
+    return result.success ? result.data! : null;
+  }
+
+  /**
+   * Quick deserialize with default options
+   */
+  static deserialize<TContext extends OnboardingContext = OnboardingContext>(
+    jsonString: string,
+  ): OnboardingStep<TContext>[] | null {
+    const result = this.fromJSON<TContext>(jsonString);
+    return result.success ? result.data! : null;
+  }
+
+  /**
+   * Create a copy of steps (serialize then deserialize)
+   */
+  static clone<TContext extends OnboardingContext = OnboardingContext>(
+    steps: OnboardingStep<TContext>[],
+  ): OnboardingStep<TContext>[] | null {
+    const serialized = this.serialize(steps);
+    return serialized ? this.deserialize<TContext>(serialized) : null;
+  }
+
+  /**
+   * Prepares step data for export by serializing it to a JSON string.
+   * This method is UI-agnostic and does not perform any DOM operations.
+   *
+   * @returns A ParseResult containing the data needed to create a file for download.
+   */
+  static getExportableData<
+    TContext extends OnboardingContext = OnboardingContext,
+  >(
+    steps: OnboardingStep<TContext>[],
+    filename: string = "onboarding-steps.json",
+    options: Partial<StepJSONParserOptions> = {},
+  ): ParseResult<ExportData> {
+    const result = this.toJSON(steps, { ...options, prettyPrint: true });
+
+    if (!result.success || !result.data) {
+      // Forward the errors and warnings from the toJSON call
+      return {
+        success: false,
+        errors: result.errors,
+        warnings: result.warnings,
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        filename,
+        mimeType: "application/json",
+        content: result.data,
+      },
+      errors: [],
+      warnings: [],
+    };
+  }
+}
+
+// =============================================================================
+// TYPE GUARDS AND UTILITIES
+// =============================================================================
+
+export namespace StepJSONParserUtils {
+  export function isValidStepJSON(json: string): boolean {
+    try {
+      const parsed = JSON.parse(json);
+      return (
+        parsed &&
+        typeof parsed === "object" &&
+        Array.isArray(parsed.steps) &&
+        parsed.steps.length > 0
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  export function getStepTypesFromJSON(json: string): OnboardingStepType[] {
+    try {
+      const parsed = JSON.parse(json) as StepJSONSchema;
+      return parsed.steps.map((step) => step.type || "INFORMATION");
+    } catch {
+      return [];
+    }
+  }
+
+  export function getStepIdsFromJSON(json: string): (string | number)[] {
+    try {
+      const parsed = JSON.parse(json) as StepJSONSchema;
+      return parsed.steps.map((step) => step.id);
+    } catch {
+      return [];
+    }
+  }
+
+  export function hasCustomComponents(json: string): boolean {
+    try {
+      const parsed = JSON.parse(json) as StepJSONSchema;
+      return (
+        parsed.metadata?.hasCustomComponents ||
+        parsed.steps.some((step) => step.type === "CUSTOM_COMPONENT")
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  export function hasFunctions(json: string): boolean {
+    try {
+      const parsed = JSON.parse(json) as StepJSONSchema;
+      return (
+        parsed.metadata?.hasFunctions ||
+        parsed.steps.some(
+          (step) =>
+            StepJSONParser["isSerializedFunction"](step.nextStep) ||
+            StepJSONParser["isSerializedFunction"](step.previousStep) ||
+            StepJSONParser["isSerializedFunction"](step.skipToStep) ||
+            StepJSONParser["isSerializedFunction"](step.onStepActive) ||
+            StepJSONParser["isSerializedFunction"](step.onStepComplete) ||
+            StepJSONParser["isSerializedFunction"](step.condition),
+        )
+      );
+    } catch {
+      return false;
+    }
+  }
+}
+
+export default StepJSONParser;

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -1,0 +1,2 @@
+export * from "./StepJSONParser";
+export * from "./types";

--- a/packages/core/src/parser/types.ts
+++ b/packages/core/src/parser/types.ts
@@ -1,0 +1,176 @@
+import {
+  OnboardingStepType,
+  InformationStepPayload,
+  MultipleChoiceStepPayload,
+  SingleChoiceStepPayload,
+  ConfirmationStepPayload,
+  CustomComponentStepPayload,
+  OnboardingContext,
+  ChecklistStepPayload,
+  ChoiceOption,
+} from "../types";
+
+export interface StepJSONParserOptions {
+  /**
+   * How to handle functions during serialization
+   * - 'serialize': Convert functions to string representations
+   * - 'omit': Remove function properties from JSON
+   * - 'placeholder': Replace with placeholder strings
+   */
+  functionHandling: "serialize" | "omit" | "placeholder";
+
+  /**
+   * Whether to include metadata in the JSON output
+   */
+  includeMeta: boolean;
+
+  /**
+   * Whether to validate steps during parsing
+   */
+  validateSteps: boolean;
+
+  /**
+   * Custom function serializer
+   */
+  customFunctionSerializer?: (
+    fn: Function,
+    propertyName: string,
+    stepId: string | number,
+  ) => string;
+
+  /**
+   * Custom function deserializer
+   */
+  customFunctionDeserializer?: (
+    fnString: string,
+    propertyName: string,
+    stepId: string | number,
+  ) => Function;
+
+  /**
+   * Whether to preserve type information in JSON
+   */
+  preserveTypes: boolean;
+
+  /**
+   * Pretty print JSON output
+   */
+  prettyPrint: boolean;
+
+  /**
+   * Include validation errors in output
+   */
+  includeValidationErrors: boolean;
+}
+
+export interface ParseResult<T> {
+  success: boolean;
+  data?: T;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface SerializedStep {
+  // Core properties
+  id: string | number;
+  type?: OnboardingStepType;
+
+  // Navigation properties (can be functions serialized as strings)
+  nextStep?: string | number | null | SerializedFunction;
+  previousStep?: string | number | null | SerializedFunction;
+  skipToStep?: string | number | null | SerializedFunction;
+
+  // Boolean properties
+  isSkippable?: boolean;
+
+  // Function properties
+  onStepActive?: SerializedFunction;
+  onStepComplete?: SerializedFunction;
+  condition?: SerializedFunction;
+
+  // Payload and metadata
+  payload?: SerializedPayload;
+  meta?: Record<string, any>;
+
+  // Type preservation
+  __type?: string;
+  __version?: string;
+}
+
+export interface SerializedFunction {
+  __isFunction: true;
+  __functionBody: string;
+  __functionName?: string;
+  __parameters?: string[];
+}
+
+export type SerializedPayload =
+  | SerializedInformationPayload
+  | SerializedMultipleChoicePayload
+  | SerializedSingleChoicePayload
+  | SerializedConfirmationPayload
+  | SerializedCustomComponentPayload
+  | SerializedChecklistPayload;
+
+export interface SerializedInformationPayload extends InformationStepPayload {
+  __payloadType: "INFORMATION";
+}
+
+export interface SerializedMultipleChoicePayload
+  extends Omit<MultipleChoiceStepPayload, "options"> {
+  __payloadType: "MULTIPLE_CHOICE";
+  options: SerializedChoiceOption[];
+}
+
+export interface SerializedSingleChoicePayload
+  extends Omit<SingleChoiceStepPayload, "options"> {
+  __payloadType: "SINGLE_CHOICE";
+  options: SerializedChoiceOption[];
+}
+
+export interface SerializedConfirmationPayload extends ConfirmationStepPayload {
+  __payloadType: "CONFIRMATION";
+}
+
+export interface SerializedCustomComponentPayload
+  extends CustomComponentStepPayload {
+  __payloadType: "CUSTOM_COMPONENT";
+}
+
+export interface SerializedChecklistPayload<
+  TContext extends OnboardingContext = OnboardingContext,
+> extends Omit<ChecklistStepPayload<TContext>, "items"> {
+  __payloadType: "CHECKLIST";
+  items: SerializedChecklistItem[];
+}
+
+export interface SerializedChoiceOption extends Omit<ChoiceOption, "value"> {
+  value: string | number;
+}
+
+export interface SerializedChecklistItem {
+  id: string;
+  label: string;
+  description?: string;
+  isMandatory?: boolean;
+  condition?: SerializedFunction;
+  meta?: Record<string, unknown>;
+}
+
+export interface StepJSONSchema {
+  version: string;
+  steps: SerializedStep[];
+  metadata?: {
+    exportedAt: string;
+    totalSteps: number;
+    stepTypes: string[];
+    hasCustomComponents: boolean;
+    hasFunctions: boolean;
+  };
+}
+
+export interface ExportData {
+  filename: string;
+  mimeType: "application/json";
+  content: string;
+}


### PR DESCRIPTION
This PR adds an OnboardingStep JSON parser allowing for OnboardingStep[] to JSON and JSON to OnboardingStep[] conversions.

This will come in handy later for Onboarding Flow visualizations.