### PR TITLE
fix: remove cache for now, changelog

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -1,81 +1,89 @@
-name: "Release Workflow"
-description: "Publish package to NPM and create a GitHub release"
+name: 'Release Workflow'
+description: 'Publish package to NPM and create a GitHub release'
 
 inputs:
-  package_path:
-    description: "Package path to publish"
-    required: true
-  package_name:
-    description: "Package name to publish"
-    required: true
-  package_version:
-    description: "Package version to publish"
-    required: true
-  npm_token:
-    description: "NPM token to publish package"
-    required: true
-  github_token:
-    description: "GitHub token to create release"
-    required: true
+    package_path:
+        description: 'Package path to publish'
+        required: true
+    package_name:
+        description: 'Package name to publish'
+        required: true
+    package_version:
+        description: 'Package version to publish'
+        required: true
+    npm_token:
+        description: 'NPM token to publish package'
+        required: true
+    github_token:
+        description: 'GitHub token to create release'
+        required: true
 
 runs:
-  using: "composite"
-  steps:
-    - name: Set up Git
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-      shell: bash
+    using: 'composite'
+    steps:
+        - name: Set up Git
+          run: |
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+          shell: bash
 
-    - name: Install dependencies
-      shell: bash
-      run: pnpm install --frozen-lockfile
+        - name: Install pnpm
+          uses: pnpm/action-setup@v4
 
-    - name: Build package
-      shell: bash
-      run: pnpm build
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+              node-version: '22'
+              registry-url: https://registry.npmjs.org
 
-    - name: Tag repository with package_name and package_version
-      shell: bash
-      run: |
-        git tag -a "${{ inputs.package_name }}@${{ inputs.package_version }}" -m "${{ inputs.package_name }}@${{ inputs.package_version }}"
+        - name: Install dependencies
+          shell: bash
+          run: pnpm install --frozen-lockfile
 
-    - name: Publish package to NPM
-      shell: bash
-      run: |
-        pnpm publish --filter=${{ inputs.package_name }} --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+        - name: Build package
+          shell: bash
+          run: pnpm build
 
-    - name: Push tag to GitHub
-      shell: bash
-      run: |
-        git push origin "${{ inputs.package_name }}@${{ inputs.package_version }}"
+        - name: Tag repository with package_name and package_version
+          shell: bash
+          run: |
+              git tag -a "${{ inputs.package_name }}@${{ inputs.package_version }}" -m "${{ inputs.package_name }}@${{ inputs.package_version }}"
 
-    - name: Create GitHub release
-      working-directory: ${{ inputs.package_path }}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-      run: |
-        # read from the first until the second header in the changelog file
-        # this assumes the formatting of the file
-        # and that this workflow is always running for the most recent entry in the file
-        LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
-        # the action we used to use was archived, and made it really difficult to create a release with a body
-        # because the LAST_CHANGELOG_ENTRY contains bash special characters so passing it between steps
-        # was a pain.
-        # we can use the github cli to create a release with a body
-        # all as part of one step
-        gh api \
-          --method POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/Somafet/onboardjs/releases \
-          -f tag_name="${{ inputs.package_name }}@${{ inputs.package_version }}" \
-        -f target_commitish='main' \
-        -f name="${{ inputs.package_name }}@${{ inputs.package_version }}" \
-        -f body="$LAST_CHANGELOG_ENTRY" \
-        -F draft=false \
-        -F prerelease=false \
-        -F generate_release_notes=false
+        - name: Publish package to NPM
+          shell: bash
+          run: |
+              pnpm publish --filter=${{ inputs.package_name }} --access public
+          env:
+              NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+
+        - name: Push tag to GitHub
+          shell: bash
+          run: |
+              git push origin "${{ inputs.package_name }}@${{ inputs.package_version }}"
+
+        - name: Create GitHub release
+          working-directory: ${{ inputs.package_path }}
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github_token }}
+          run: |
+              # Check if CHANGELOG.md exists and read from it, otherwise use a default message
+              if [ -f "CHANGELOG.md" ]; then
+                  LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+              else
+                  LAST_CHANGELOG_ENTRY="Release ${{ inputs.package_version }} of ${{ inputs.package_name }}. See the repository for more details."
+              fi
+
+              # Create GitHub release
+              gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/Somafet/onboardjs/releases \
+                -f tag_name="${{ inputs.package_name }}@${{ inputs.package_version }}" \
+              -f target_commitish='main' \
+              -f name="${{ inputs.package_name }}@${{ inputs.package_version }}" \
+              -f body="$LAST_CHANGELOG_ENTRY" \
+              -F draft=false \
+              -F prerelease=false \
+              -F generate_release_notes=false

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,39 +1,38 @@
-name: "Setup Workspace Environment"
-description: "Sets up a Node.js environment and installs dependencies"
+name: 'Setup Workspace Environment'
+description: 'Sets up a Node.js environment and installs dependencies'
 
 inputs:
-  node_version:
-    description: "Node.js version to use"
-    required: false
-    default: "22"
-  install:
-    description: "Whether to install dependencies"
-    required: false
-    default: "true"
-  build:
-    description: "Whether to build the project"
-    required: false
-    default: "true"
+    node_version:
+        description: 'Node.js version to use'
+        required: false
+        default: '22'
+    install:
+        description: 'Whether to install dependencies'
+        required: false
+        default: 'true'
+    build:
+        description: 'Whether to build the project'
+        required: false
+        default: 'true'
 
 runs:
-  using: "composite"
-  steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
+    using: 'composite'
+    steps:
+        - name: Install pnpm
+          uses: pnpm/action-setup@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ inputs.node_version }}
-        registry-url: https://registry.npmjs.org
-        cache: "pnpm"
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+              node-version: ${{ inputs.node_version }}
+              registry-url: https://registry.npmjs.org
 
-    - name: Install package.json dependencies with pnpm
-      if: ${{ inputs.install == 'true' }}
-      shell: bash
-      run: pnpm install --frozen-lockfile
+        - name: Install package.json dependencies with pnpm
+          if: ${{ inputs.install == 'true' }}
+          shell: bash
+          run: pnpm install --frozen-lockfile
 
-    - name: Build project with pnpm
-      if: ${{ inputs.build == 'true' }}
-      shell: bash
-      run: pnpm build
+        - name: Build project with pnpm
+          if: ${{ inputs.build == 'true' }}
+          shell: bash
+          run: pnpm build


### PR DESCRIPTION
## Problem

The publish workflows were failing with multiple issues

## Changes

- Remove the cache option for now
- Check if CHANGELOG.md exists and read from it, otherwise use a default message

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] @onboardjs/core (headless)
- [ ] @onboardjs/react (React)
- [ ] @onboardjs/visualizer (React)
- [ ] @onboardjs/posthog-plugin (plugin)
- [ ] @onboardjs/supabase-plugin (plugin)
- [ ] @onboardjs/mixpanel-plugin (plugin)

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
