### PR TITLE
fix: actually version bump

### DIFF
--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@onboardjs/visualizer",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "A React component library to visually build and edit OnboardJS flows.",
     "author": "Soma Somorjai <soma@onboardjs.com>",
     "license": "MIT",


### PR DESCRIPTION
## Problem

Missed the version bump

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] @onboardjs/core (headless)
- [ ] @onboardjs/react (React)
- [ ] @onboardjs/visualizer (React)
- [ ] @onboardjs/posthog-plugin (plugin)
- [ ] @onboardjs/supabase-plugin (plugin)
- [ ] @onboardjs/mixpanel-plugin (plugin)

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
