### PR TITLE
feat: register-analytics-events

### DIFF
--- a/.changeset/fruity-things-add.md
+++ b/.changeset/fruity-things-add.md
@@ -1,0 +1,5 @@
+---
+'@onboardjs/core': minor
+---
+
+Add in some unregistered events to the analytics manager.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,42 +1,42 @@
 {
-  "name": "@onboardjs/core",
-  "version": "0.3.8",
-  "description": "Headless core logic for dynamic onboarding flows.",
-  "private": false,
-  "author": {
-    "name": "Soma Somorjai",
-    "email": "soma@onboardjs.com",
-    "url": "https://somafet.com"
-  },
-  "keywords": [
-    "onboardjs",
-    "onboarding",
-    "core",
-    "headless",
-    "typescript"
-  ],
-  "files": [
-    "dist"
-  ],
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
-    }
-  },
-  "scripts": {
-    "build": "vite build && tsc --emitDeclarationOnly true",
-    "test": "vitest --coverage"
-  },
-  "devDependencies": {
-    "@types/node": "^24.3.0",
-    "@vitest/coverage-v8": "^3.1.4",
-    "typescript": "^5.8.3",
-    "vitest": "^3.1.4"
-  },
-  "license": "MIT"
+    "name": "@onboardjs/core",
+    "version": "0.3.9",
+    "description": "Headless core logic for dynamic onboarding flows.",
+    "private": false,
+    "author": {
+        "name": "Soma Somorjai",
+        "email": "soma@onboardjs.com",
+        "url": "https://somafet.com"
+    },
+    "keywords": [
+        "onboardjs",
+        "onboarding",
+        "core",
+        "headless",
+        "typescript"
+    ],
+    "files": [
+        "dist"
+    ],
+    "main": "dist/index.cjs.js",
+    "module": "dist/index.es.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.es.js",
+            "require": "./dist/index.cjs.js"
+        }
+    },
+    "scripts": {
+        "build": "vite build && tsc --emitDeclarationOnly true",
+        "test": "vitest --coverage"
+    },
+    "devDependencies": {
+        "@types/node": "^24.3.0",
+        "@vitest/coverage-v8": "^3.1.4",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.4"
+    },
+    "license": "MIT"
 }


### PR DESCRIPTION
## Problem

Many of the analytics events were unregistered in the OnboardingEngine.

## Changes

The events are now sent.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] @onboardjs/core (headless)
- [ ] @onboardjs/react (React)
- [ ] @onboardjs/visualizer (React)
- [ ] @onboardjs/posthog-plugin (plugin)
- [ ] @onboardjs/supabase-plugin (plugin)
- [ ] @onboardjs/mixpanel-plugin (plugin)

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
