### PR TITLE
fix: resolve React 18 Strict Mode race condition and hydration state …

### DIFF
--- a/.changeset/fix-react-strict-mode-hydration.md
+++ b/.changeset/fix-react-strict-mode-hydration.md
@@ -1,0 +1,12 @@
+---
+'@onboardjs/core': patch
+'@onboardjs/react': patch
+---
+
+Fix React 18 Strict Mode race condition causing isHydrating to get stuck
+
+This fix addresses two overlapping issues:
+
+1. **Race condition in useEngineLifecycle.ts**: Replaced shared `useRef` with an effect-scoped flag to prevent orphaned promises from previous effect runs from updating state during Strict Mode double-mounting.
+
+2. **Missing state notification in OnboardingEngine.ts**: Added `notifyStateChange` call in the `finally` block of `_initializeEngine` to ensure React and other subscribers are notified when hydration completes.

--- a/packages/core/src/engine/OnboardingEngine.ts
+++ b/packages/core/src/engine/OnboardingEngine.ts
@@ -292,6 +292,14 @@ export class OnboardingEngine<TContext extends OnboardingContext = OnboardingCon
             } finally {
                 this._coreEngineService.setHydrating(false)
                 this._updateLoadingState()
+                // Notify listeners that hydration is complete. This ensures React
+                // and other subscribers are informed of the final initialization state,
+                // even if hydration completed while they were subscribing.
+                this._coreEngineService.notifyStateChange(
+                    this._currentStepInternal,
+                    this._contextInternal,
+                    this._history
+                )
             }
         })
     }


### PR DESCRIPTION
…notification

Fix two overlapping issues causing the engine to get stuck with isHydrating: true:

1. Race condition in useEngineLifecycle.ts: Replace shared useRef with effect-scoped flag to prevent orphaned promises from previous effect runs from updating state during Strict Mode double-mounting.

2. Missing state notification in OnboardingEngine.ts: Add notifyStateChange call in the finally block of _initializeEngine to ensure React and other subscribers are notified when hydration completes.

Added tests:
- StrictMode integration tests for useEngineLifecycle
- Hydration notification tests for OnboardingEngine

## Problem

When using @onboardjs/react with React 18 Strict Mode, the engine gets permanently stuck with isHydrating: true. This occurs due to two overlapping issues:

Race condition in useEngineLifecycle.ts: The hook uses a component-level useRef (isMountedRef) to guard against state updates after unmount. In React 18 Strict Mode, components double-mount, creating Engine 1 and Engine 2. When Engine 1's ready() promise resolves, it sees isMountedRef.current is true (reset by Engine 2's effect) and incorrectly calls setIsReady(true), causing useEngineState to read Engine 2's state before it finishes hydrating.
Missing state notification in OnboardingEngine.ts: When the engine finishes _initializeEngine, the finally block sets isHydrating to false but never calls notifyStateChange(). Listeners subscribed during hydration are never notified that hydration is complete.

## Changes

packages/react/src/hooks/internal/useEngineLifecycle.ts

Removed the shared useRef pattern (isMountedRef)
Replaced with an effect-scoped let isEffectActive = true flag
Each effect invocation now has its own isolated flag that cannot be polluted by subsequent invocations
packages/core/src/engine/OnboardingEngine.ts

Added notifyStateChange() call in the finally block of _initializeEngine
Ensures all listeners are notified when hydration completes (success or error)
packages/react/src/hooks/internal/useEngineLifecycle.test.tsx (renamed from .ts)

Added two StrictMode integration tests validating the race condition fix
packages/core/src/engine/OnboardingEngine.test.ts

Added two tests validating hydration state notification

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] @onboardjs/core (headless)
- [x] @onboardjs/react (React)
- [ ] @onboardjs/visualizer (React)
- [ ] @onboardjs/posthog-plugin (plugin)
- [ ] @onboardjs/supabase-plugin (plugin)
- [ ] @onboardjs/mixpanel-plugin (plugin)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
